### PR TITLE
Alex/Malickosti-vol.10

### DIFF
--- a/src/components/calibrationScript.js
+++ b/src/components/calibrationScript.js
@@ -300,7 +300,7 @@ function exportCalibrationFile() {
     }
 
     const filenameInput = document.getElementById("exportCalibrationNameInput").value.trim();
-    const filename = filenameInput !== "" ? filenameInput : "calibration_points.txt";
+    const filename = filenameInput !== "" ? filenameInput : `calibration_points_${getTimestamp()}.txt`;
 
     const finalFilename = filename.endsWith(".txt") ? filename : filename + ".txt";
 

--- a/src/components/calibrationScript.js
+++ b/src/components/calibrationScript.js
@@ -587,7 +587,7 @@ function drawGridDivergence() {
 
     const xMin = rangeBeginX;
     const xMax = rangeEndX;
-    const xStep = 200;
+    const xStep = 40;
 
     const deltas = divergencePoints.map(p => p.delta);
     let maxAbs = Math.max(...deltas.map(Math.abs));
@@ -617,14 +617,18 @@ function drawGridDivergence() {
     }
 
     for (let xVal = xMin; xVal <= xMax; xVal += xStep) {
+        const isMultiple200 = xVal % 200 === 0;
+        const isEndpoint = (xVal === xMin || xVal === xMax);
         const x = padding + ((xVal - xMin) / (xMax - xMin)) * (width - 2 * padding);
 
-        graphCtxDivergence.moveTo(x, padding);
-        graphCtxDivergence.lineTo(x, height - padding);
+        if (isMultiple200 || isEndpoint) {
+            graphCtxDivergence.moveTo(x, padding);
+            graphCtxDivergence.lineTo(x, height - padding);
 
-        const label = xVal.toFixed(0);
-        const textWidth = graphCtxDivergence.measureText(label).width;
-        graphCtxDivergence.fillText(label, x - textWidth / 2, height - padding + 15);
+            const label = xVal.toFixed(0);
+            const textWidth = graphCtxDivergence.measureText(label).width;
+            graphCtxDivergence.fillText(label, x - textWidth / 2, height - padding + 15);
+        }
     }
 
     graphCtxDivergence.font = '11px Arial';

--- a/src/components/dataSavingScript.js
+++ b/src/components/dataSavingScript.js
@@ -49,7 +49,7 @@ function saveGraphValues() {
         // result.push([ x, nm, intensity, r, g, b ]);
         result.push([ x, nm, r, g, b ]);
     }
-    const filename = "values.xlsx"
+    const filename = `values_${getTimestamp()}.xlsx`
 
     const worksheet = XLSX.utils.aoa_to_sheet(result);
     const workbook = XLSX.utils.book_new();
@@ -82,7 +82,7 @@ function saveGraphImage(){
 
     const link = document.createElement('a');
     link.href = graphImageData;
-    link.download = 'graph.png';
+    link.download = `graph_${getTimestamp()}.png`;
     link.click();
 
     if (!wasPaused) {
@@ -114,10 +114,27 @@ function saveCameraImage(){
 
     const link = document.createElement('a');
     link.href = videoImageData;
-    link.download = 'image.png';
+    link.download = `image_${getTimestamp()}.png`;
     link.click();
 
     if (!wasPaused) {
         videoElement.play();
     }
+}
+
+/**
+ * Returns a string with a date-time stamp
+ */
+function getTimestamp() {
+    const now = new Date();
+
+    const year = now.getFullYear();
+    const month = String(now.getMonth() + 1).padStart(2, '0');
+    const day = String(now.getDate()).padStart(2, '0');
+
+    const hours = String(now.getHours()).padStart(2, '0');
+    const minutes = String(now.getMinutes()).padStart(2, '0');
+    const seconds = String(now.getSeconds()).padStart(2, '0');
+
+    return `${day}-${month}-${year}_${hours}-${minutes}-${seconds}`;
 }

--- a/src/components/graphScript.js
+++ b/src/components/graphScript.js
@@ -888,6 +888,10 @@ function resizeCanvasToDisplaySize(ctx, canvas, type) {
         drawGridCalibration();
         drawCalibrationLine();
         drawCalibrationPoints();
+    } else if (type === "Divergence") {
+        drawGridDivergence();
+        drawDivergenceLine();
+        drawDivergencePoints();
     } else if (type === "Normal") {
         plotRGBLineFromCamera();
     }

--- a/src/components/setupScript.js
+++ b/src/components/setupScript.js
@@ -88,7 +88,9 @@ function changeDisplayScreen(action) {
         leftHandle.classList.toggle('moved');
         leftDetectionArea.classList.toggle('moved');
 
-        playVideo();
+        if (!videoElement.paused) {
+            playVideo();
+        }
     } else if (action === "imgSelect") {
         const isHidden = imageSelection.classList.toggle('hidden');
         rightHandle.innerHTML = isHidden ? '↩' : '↪';

--- a/src/components/setupScript.js
+++ b/src/components/setupScript.js
@@ -88,7 +88,8 @@ function changeDisplayScreen(action) {
         leftHandle.classList.toggle('moved');
         leftDetectionArea.classList.toggle('moved');
 
-        if (!videoElement.paused) {
+        const playButton = document.getElementById("playVideoButton");
+        if (window.getComputedStyle(playButton).visibility === 'hidden') {
             playVideo();
         }
     } else if (action === "imgSelect") {

--- a/src/components/setupScript.js
+++ b/src/components/setupScript.js
@@ -40,6 +40,7 @@ function changeSettingsScreen(changeTo) {
         changeDisplayScreen('settings');
 
         resizeCanvasToDisplaySize(graphCtxCalibration, graphCanvasCalibration, "Calibration");
+        resizeCanvasToDisplaySize(graphCtxDivergence, graphCanvasDivergence, "Divergence");
     } else if (changeTo === "LongExpo") {
         show('graphWindowContainer');
         show('videoMainWindow');

--- a/src/languages/en.json
+++ b/src/languages/en.json
@@ -110,12 +110,12 @@
 
   "acknowledge": "I understand",
   "noNmNeedToCalibrate" : "To show graph in nm, please first calibrate.",
-  "exposureUnsupportedBrowser" : "Exposure control is not supported in your browser, this setting will not be available",
+  "exposureUnsupportedBrowser" : "Exposure control is not supported by your browser or your camera, this setting will not be available",
 
   "notEnoughCalPointsError" : "Insufficient number of calibration points",
   "noCalPointsToExportError" : "No calibration data to export. Please calibrate first.",
   "noFileSelectedError" : "Please select a file.",
-  "wrongNumberOfCalPointsError" : "Calibration must contain between 4 and 15 points!",
+  "wrongNumberOfCalPointsError" : "Calibration must contain between 2 and 15 points!",
   "wrongCalPointsFormatError" : "Wrong calibration points format!",
   "cameraNotFoundError" : "Camera has not been found",
   "cameraAccessDeniedError" : "Camera access was denied.",

--- a/src/languages/sk.json
+++ b/src/languages/sk.json
@@ -111,12 +111,12 @@
 
   "acknowledge": "Rozumiem",
   "noNmNeedToCalibrate" : "Pre zobrazenie grafu v nm je potrebné nakalibrovať.",
-  "exposureUnsupportedBrowser" : "Ovládanie expozičnej doby nie je vo Vašom prehliadači podporované, toto nastavenie nebude k dispozícii.",
+  "exposureUnsupportedBrowser" : "Ovládanie expozičnej doby nie je podporované vo Vašom prehliadači alebo kamere, toto nastavenie nebude k dispozícii.",
 
   "notEnoughCalPointsError" : "Nedostatočný počet kalibračných bodov",
   "noCalPointsToExportError" : "Žiadne kalibračné dáta pre export. Najprv prosím nakalibrujte.",
   "noFileSelectedError" : "Prosím vyberte súbor.",
-  "wrongNumberOfCalPointsError" : "Kalibrácia musí obsahovať medzi 4 a 15 bodov!",
+  "wrongNumberOfCalPointsError" : "Kalibrácia musí obsahovať medzi 2 a 15 bodov!",
   "wrongCalPointsFormatError" : "Nesprávny formát kalibračných bodov!",
   "cameraNotFoundError" : "Kamera sa nenašla.",
   "cameraAccessDeniedError" : "Prístup ku kamere bol zamietnutý.",

--- a/src/pages/recording.html
+++ b/src/pages/recording.html
@@ -247,9 +247,10 @@
 
       </div>
 
-      <div id="calibrationWindowContainer" class="w-100" style="display: none; background-color: #d74343;">
+      <div id="calibrationWindowContainer" style="display: none">
         <div id="graphWindowCalibration" class="w-100">
           <canvas id="graphCalibration"></canvas>
+          <canvas id="graphDivergence"></canvas>
         </div>
       </div>
 

--- a/src/styles/recordingStyle.css
+++ b/src/styles/recordingStyle.css
@@ -226,16 +226,20 @@ html, body {
 
 /* ##### Calibration Graph ##### */
 #graphWindowCalibration {
-    width: 100%;
-    max-height: 100%;
-    aspect-ratio: 896 / 455;
     box-sizing: border-box;
 }
 
 #graphCalibration {
     width: 100%;
-    height: 100%;
-    display: block;
+    height: calc(50vh - 0.75rem);
+    display: flex;
+    margin-bottom: 0.5rem;
+}
+
+#graphDivergence {
+    width: 100%;
+    height: calc(50vh - 0.75rem);
+    display: flex;
 }
 
 /* ##### Long exposure popup ##### */


### PR DESCRIPTION
- Left panel no longer interferes with the camera/loaded image
- Saved files now include a date-time stamp (camera image, graph image, excel values, generic calibration)
- Changed error message for when exposition is unsupported
- Created a graph to show the difference between calculated and ideal calibration functions
- Made a change to the setup of calibration math so it computes more precisely

**Known issue I couldn't bother fixing**
Sometimes when the screen is resized the calibration graph creates a jump at the end

<img width="498" height="498" alt="placeholder" src="https://github.com/user-attachments/assets/167778d3-0842-4b2a-aa56-950333f99bf6" />